### PR TITLE
Exclude injector.cpp in other OS except windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,12 @@
                 "<!(node -e \"require('nan')\")"
             ],
             "target_name": "injector",
-            "sources": ["injector.cpp"]
-        }
+            "sources": ["injector.cpp"],
+            'conditions': [
+                ['OS != "win"', {
+                    'sources!': ['injector.cpp']
+                }
+            ]
+        ]}
     ]
 }


### PR DESCRIPTION
At this moment, If we try to install `node-dll-injector` in Mac or Linux, it just fails. 
This PR fixes that. 